### PR TITLE
Add gemini 3 flash preview to ai food analysis

### DIFF
--- a/FreeAPS/Sources/Services/FoodSearch/Model/AITypes.swift
+++ b/FreeAPS/Sources/Services/FoodSearch/Model/AITypes.swift
@@ -161,6 +161,7 @@ enum OpenAIModel: String, AIModelBase, Encodable {
 enum GeminiModel: String, AIModelBase, Encodable {
     case gemini_2_5_pro = "gemini-2.5-pro"
     case gemini_2_5_flash = "gemini-2.5-flash"
+    case gemini_3_flash_preview = "gemini-3-flash-preview"
     case gemini_3_pro_preview = "gemini-3-pro-preview"
     case gemini_3_1_pro_preview = "gemini-3.1-pro-preview"
 
@@ -168,6 +169,7 @@ enum GeminiModel: String, AIModelBase, Encodable {
         switch self {
         case .gemini_2_5_pro: false
         case .gemini_2_5_flash: true
+        case .gemini_3_flash_preview: true
         case .gemini_3_pro_preview: false
         case .gemini_3_1_pro_preview: false
         }
@@ -177,6 +179,7 @@ enum GeminiModel: String, AIModelBase, Encodable {
         switch self {
         case .gemini_2_5_pro: 0.01
         case .gemini_2_5_flash: 0.01
+        case .gemini_3_flash_preview: 0.01
         case .gemini_3_pro_preview: 0.01
         case .gemini_3_1_pro_preview: 0.01
         }
@@ -186,6 +189,7 @@ enum GeminiModel: String, AIModelBase, Encodable {
         switch self {
         case .gemini_2_5_pro: "2.5 Pro"
         case .gemini_2_5_flash: "2.5 Flash"
+        case .gemini_3_flash_preview: "3 Flash Preview"
         case .gemini_3_pro_preview: "3 Pro Preview"
         case .gemini_3_1_pro_preview: "3.1 Pro Preview"
         }
@@ -195,6 +199,7 @@ enum GeminiModel: String, AIModelBase, Encodable {
         switch self {
         case .gemini_2_5_pro: 40
         case .gemini_2_5_flash: 30
+        case .gemini_3_flash_preview: 35
         case .gemini_3_pro_preview: 45
         case .gemini_3_1_pro_preview: 45
         }
@@ -204,6 +209,7 @@ enum GeminiModel: String, AIModelBase, Encodable {
         switch self {
         case .gemini_2_5_pro: 15
         case .gemini_2_5_flash: 10
+        case .gemini_3_flash_preview: 10
         case .gemini_3_pro_preview: 15
         case .gemini_3_1_pro_preview: 15
         }
@@ -224,6 +230,7 @@ enum GeminiModel: String, AIModelBase, Encodable {
         case .gemini_2_5_flash,
              .gemini_2_5_pro,
              .gemini_3_1_pro_preview,
+             .gemini_3_flash_preview,
              .gemini_3_pro_preview: 2048
         }
     }
@@ -392,6 +399,7 @@ enum ImageSearchProvider {
         .aiModel(.openAI(.gpt_5_1)),
         .aiModel(.openAI(.gpt_5_2)),
         .aiModel(.openAI(.gpt_5_4)),
+        .aiModel(.gemini(.gemini_3_flash_preview)),
         .aiModel(.gemini(.gemini_3_pro_preview)),
         .aiModel(.gemini(.gemini_3_1_pro_preview)),
         .aiModel(.gemini(.gemini_2_5_pro)),
@@ -442,6 +450,7 @@ enum AITextProvider {
         .aiModel(.openAI(.gpt_5_1)),
         .aiModel(.openAI(.gpt_5_2)),
         .aiModel(.openAI(.gpt_5_4)),
+        .aiModel(.gemini(.gemini_3_flash_preview)),
         .aiModel(.gemini(.gemini_3_1_pro_preview)),
         .aiModel(.gemini(.gemini_3_pro_preview)),
         .aiModel(.gemini(.gemini_2_5_pro)),


### PR DESCRIPTION
Add gemini 3 flash preview to ai food analysis.

Useful as a fast/cheap model.